### PR TITLE
Fix build issue with alarms test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
   "pcaspy@git+https://github.com/ISISComputingGroup/pcaspy",
   "genie-python[plot]",
-    "CaChannel@git+https://github.com/ISISComputingGroup/CaChannel.git",
+    "CaChannel",
     "mock",
     "parameterized",
     "pysnmp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
   "pcaspy@git+https://github.com/ISISComputingGroup/pcaspy",
   "genie-python[plot]",
-    "CaChannel",
+    "CaChannel@git+https://github.com/ISISComputingGroup/CaChannel.git",
     "mock",
     "parameterized",
     "pysnmp",


### PR DESCRIPTION
CaChannel made to point to our fork instead of the public repo. This fixes the test failure issues in server_common build.