### PR TITLE
remove use of hamcrest

### DIFF
--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        version: ['3.12']
+        version: ['3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        version: ['3.12', '3.13']
+        version: ['3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -5,13 +5,13 @@ jobs:
     uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@main
     with:
       compare-branch: origin/main
-      python-ver: '3.11'
+      python-ver: '3.12'
       runs-on: windows-latest
   tests:
     runs-on: windows-latest
     strategy:
       matrix:
-        version: ['3.11']
+        version: ['3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
   # checked by "pip install". See instead "requires-python" key in this file.
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ dependencies = [
   "pcaspy",
   "genie-python[plot]",
   "CaChannel",
-  "mock",
-  "parameterized",
   "pysnmp",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
   # checked by "pip install". See instead "requires-python" key in this file.
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ classifiers = [
   # that you indicate you support Python 3. These classifiers are *not*
   # checked by "pip install". See instead "requires-python" key in this file.
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3 :: Only",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "server_common"  # REQUIRED, is the only field that cannot be marked as d
 dynamic = ["version"]
 description = "A collection of utilities for python based IOC servers used at ISIS"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {file = "LICENSE"}
 
 authors = [
@@ -34,7 +34,6 @@ classifiers = [
   # that you indicate you support Python 3. These classifiers are *not*
   # checked by "pip install". See instead "requires-python" key in this file.
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3 :: Only",
@@ -47,7 +46,6 @@ dependencies = [
   "mock",
   "parameterized",
   "pysnmp",
-  "PyHamcrest"
 ]
 
 [project.optional-dependencies]

--- a/src/server_common/test_modules/test_autosave.py
+++ b/src/server_common/test_modules/test_autosave.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
-import shutil
-import unittest
-
-from parameterized import parameterized
+import pytest
 
 from server_common.autosave import (
     AutosaveFile,
@@ -13,139 +9,143 @@ from server_common.autosave import (
     OptionalIntConversion,
 )
 
-TEMP_FOLDER = os.path.join("C:\\", "instrument", "var", "tmp", "autosave_tests")
+
+@pytest.fixture
+def autosave_file(tmpdir):
+    # for some reason we do actual file i/o in these tests... fine
+    yield AutosaveFile(service_name="unittests", file_name="test_file", folder=tmpdir)
 
 
-class TestAutosave(unittest.TestCase):
-    def setUp(self):
-        try:
-            os.makedirs(TEMP_FOLDER)
-        except OSError:
-            pass
-        self.autosave = AutosaveFile(
-            service_name="unittests", file_name="test_file", folder=TEMP_FOLDER
-        )
+def test_GIVEN_no_existing_file_WHEN_get_parameter_from_autosave_THEN_default_returned(
+    autosave_file,
+):
+    default = object()
+    assert autosave_file.read_parameter("some_random_parameter", default) == default
 
-    def test_GIVEN_no_existing_file_WHEN_get_parameter_from_autosave_THEN_default_returned(self):
-        default = object()
-        self.assertEqual(self.autosave.read_parameter("some_random_parameter", default), default)
 
-    def test_GIVEN_parameter_saved_WHEN_get_parameter_from_autosave_THEN_saved_value_returned(self):
-        value = "test_value"
-        self.autosave.write_parameter("parameter", value)
-        self.assertEqual(self.autosave.read_parameter("parameter", None), value)
+def test_GIVEN_parameter_saved_WHEN_get_parameter_from_autosave_THEN_saved_value_returned(
+    autosave_file,
+):
+    value = "test_value"
+    autosave_file.write_parameter("parameter", value)
+    assert autosave_file.read_parameter("parameter", None) == value
 
-    def test_GIVEN_different_parameter_saved_WHEN_get_parameter_from_autosave_THEN_saved_value_returned(
-        self,
-    ):
-        value = "test_value"
-        self.autosave.write_parameter("other_parameter", value)
-        self.assertEqual(self.autosave.read_parameter("parameter", None), None)
 
-    def test_GIVEN_parameter_saved_with_different_strategy_WHEN_get_parameter_from_autosave_THEN_saved_value_returned(
-        self,
-    ):
-        class Strategy:
-            @staticmethod
-            def autosave_convert_for_write(values):
-                return ",".join([str(value) for value in values])
+def test_GIVEN_different_parameter_saved_WHEN_get_parameter_from_autosave_THEN_saved_value_returned(
+    autosave_file,
+):
+    value = "test_value"
+    autosave_file.write_parameter("other_parameter", value)
+    assert autosave_file.read_parameter("parameter", None) is None
 
-            @staticmethod
-            def autosave_convert_for_read(auto_save_value):
-                return [int(i) for i in auto_save_value.split(",")]
 
-        autosave = AutosaveFile(
-            service_name="unittests",
-            file_name="strat_test_file",
-            folder=TEMP_FOLDER,
-            conversion=Strategy(),
-        )
-        value = [1, 2]
-        autosave.write_parameter("parameter_ab", value)
-        self.assertEqual(autosave.read_parameter("parameter_ab", None), value)
+def test_GIVEN_parameter_saved_with_different_strategy_WHEN_get_parameter_from_autosave_THEN_saved_value_returned(
+    tmpdir,
+):
+    class Strategy:
+        @staticmethod
+        def autosave_convert_for_write(values):
+            return ",".join([str(value) for value in values])
 
-    def test_GIVEN_parameter_saved_as_float_WHEN_get_parameter_from_autosave_THEN_value_returned_as_float(
-        self,
-    ):
-        value = 0.173
-        key = "parameter"
-        autosave = AutosaveFile(
-            service_name="unittests",
-            file_name="test_file",
-            folder=TEMP_FOLDER,
-            conversion=FloatConversion(),
-        )
+        @staticmethod
+        def autosave_convert_for_read(auto_save_value):
+            return [int(i) for i in auto_save_value.split(",")]
 
-        autosave.write_parameter(key, value)
-        result = autosave.read_parameter(key, None)
+    autosave = AutosaveFile(
+        service_name="unittests",
+        file_name="strat_test_file",
+        folder=tmpdir,
+        conversion=Strategy(),
+    )
+    value = [1, 2]
+    autosave.write_parameter("parameter_ab", value)
+    assert autosave.read_parameter("parameter_ab", None) == value
 
-        assert result == value
 
-    def test_GIVEN_parameter_can_not_be_saved_as_float_WHEN_get_parameter_from_autosave_THEN_none_returned(
-        self,
-    ):
-        value = "string not a float"
-        key = "parameter"
-        autosave = AutosaveFile(
-            service_name="unittests",
-            file_name="test_file",
-            folder=TEMP_FOLDER,
-            conversion=FloatConversion(),
-        )
+def test_GIVEN_parameter_saved_as_float_WHEN_get_parameter_from_autosave_THEN_value_returned_as_float(
+    tmpdir,
+):
+    value = 0.173
+    key = "parameter"
+    autosave = AutosaveFile(
+        service_name="unittests",
+        file_name="test_file",
+        folder=tmpdir,
+        conversion=FloatConversion(),
+    )
 
-        autosave.write_parameter(key, value)
-        result = autosave.read_parameter(key, None)
+    autosave.write_parameter(key, value)
+    result = autosave.read_parameter(key, None)
 
-        assert result is None
+    assert result == value
 
-    @parameterized.expand([(True,), (False,)])
-    def test_GIVEN_true_saved_as_bool_WHEN_get_parameter_from_autosave_THEN_value_returned_as_ture(
-        self, value
-    ):
-        key = "parameter"
-        autosave = AutosaveFile(
-            service_name="unittests",
-            file_name="test_file",
-            folder=TEMP_FOLDER,
-            conversion=BoolConversion(),
-        )
 
-        autosave.write_parameter(key, value)
-        result = autosave.read_parameter(key, None)
+def test_GIVEN_parameter_can_not_be_saved_as_float_WHEN_get_parameter_from_autosave_THEN_none_returned(
+    tmpdir,
+):
+    value = "string not a float"
+    key = "parameter"
+    autosave = AutosaveFile(
+        service_name="unittests",
+        file_name="test_file",
+        folder=tmpdir,
+        conversion=FloatConversion(),
+    )
 
-        assert result == value
+    autosave.write_parameter(key, value)
+    result = autosave.read_parameter(key, None)
 
-    def test_GIVEN_parameter_can_not_be_saved_as_bool_WHEN_get_parameter_from_autosave_THEN_none_returned(
-        self,
-    ):
-        value = "string not a bool"
-        key = "parameter"
-        autosave = AutosaveFile(
-            service_name="unittests",
-            file_name="test_file",
-            folder=TEMP_FOLDER,
-            conversion=BoolConversion(),
-        )
+    assert result is None
 
-        autosave.write_parameter(key, value)
-        result = autosave.read_parameter(key, None)
 
-        assert result is None
+@pytest.mark.parametrize("value", [True, False])
+def test_GIVEN_true_saved_as_bool_WHEN_get_parameter_from_autosave_THEN_value_returned_as_ture(
+    tmpdir,
+    value,
+):
+    key = "parameter"
+    autosave = AutosaveFile(
+        service_name="unittests",
+        file_name="test_file",
+        folder=tmpdir,
+        conversion=BoolConversion(),
+    )
 
-    @parameterized.expand([(1,), (None,)])
-    def test_GIVEN_int_or_None_WHEN_get_parameter_from_autosave_THEN_value_returned(self, value):
-        key = "parameter"
-        autosave = AutosaveFile(
-            service_name="unittests",
-            file_name="test_file",
-            folder=TEMP_FOLDER,
-            conversion=OptionalIntConversion(),
-        )
+    autosave.write_parameter(key, value)
+    result = autosave.read_parameter(key, None)
 
-        autosave.write_parameter(key, value)
-        result = autosave.read_parameter(key, "not read")
+    assert result == value
 
-        assert result == value
 
-    def tearDown(self):
-        shutil.rmtree(TEMP_FOLDER, ignore_errors=True)
+def test_GIVEN_parameter_can_not_be_saved_as_bool_WHEN_get_parameter_from_autosave_THEN_none_returned(
+    tmpdir,
+):
+    value = "string not a bool"
+    key = "parameter"
+    autosave = AutosaveFile(
+        service_name="unittests",
+        file_name="test_file",
+        folder=tmpdir,
+        conversion=BoolConversion(),
+    )
+
+    autosave.write_parameter(key, value)
+    result = autosave.read_parameter(key, None)
+
+    assert result is None
+
+
+@pytest.mark.parametrize("value", [1, None])
+def test_GIVEN_int_or_None_WHEN_get_parameter_from_autosave_THEN_value_returned(tmpdir, value):
+    key = "parameter"
+    autosave = AutosaveFile(
+        service_name="unittests",
+        file_name="test_file",
+        folder=tmpdir,
+        conversion=OptionalIntConversion(),
+    )
+
+    autosave.write_parameter(key, value)
+    result = autosave.read_parameter(key, "not read")
+
+    assert result == value

--- a/src/server_common/test_modules/test_autosave.py
+++ b/src/server_common/test_modules/test_autosave.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import unittest
 
-from hamcrest import *
 from parameterized import parameterized
 
 from server_common.autosave import (
@@ -80,7 +79,7 @@ class TestAutosave(unittest.TestCase):
         autosave.write_parameter(key, value)
         result = autosave.read_parameter(key, None)
 
-        assert_that(result, is_(value))
+        assert result == value
 
     def test_GIVEN_parameter_can_not_be_saved_as_float_WHEN_get_parameter_from_autosave_THEN_none_returned(
         self,
@@ -97,7 +96,7 @@ class TestAutosave(unittest.TestCase):
         autosave.write_parameter(key, value)
         result = autosave.read_parameter(key, None)
 
-        assert_that(result, is_(None))
+        assert result is None
 
     @parameterized.expand([(True,), (False,)])
     def test_GIVEN_true_saved_as_bool_WHEN_get_parameter_from_autosave_THEN_value_returned_as_ture(
@@ -114,7 +113,7 @@ class TestAutosave(unittest.TestCase):
         autosave.write_parameter(key, value)
         result = autosave.read_parameter(key, None)
 
-        assert_that(result, is_(value))
+        assert result == value
 
     def test_GIVEN_parameter_can_not_be_saved_as_bool_WHEN_get_parameter_from_autosave_THEN_none_returned(
         self,
@@ -131,7 +130,7 @@ class TestAutosave(unittest.TestCase):
         autosave.write_parameter(key, value)
         result = autosave.read_parameter(key, None)
 
-        assert_that(result, is_(None))
+        assert result is None
 
     @parameterized.expand([(1,), (None,)])
     def test_GIVEN_int_or_None_WHEN_get_parameter_from_autosave_THEN_value_returned(self, value):
@@ -146,7 +145,7 @@ class TestAutosave(unittest.TestCase):
         autosave.write_parameter(key, value)
         result = autosave.read_parameter(key, "not read")
 
-        assert_that(result, is_(value))
+        assert result == value
 
     def tearDown(self):
         try:

--- a/src/server_common/test_modules/test_autosave.py
+++ b/src/server_common/test_modules/test_autosave.py
@@ -20,7 +20,7 @@ class TestAutosave(unittest.TestCase):
     def setUp(self):
         try:
             os.makedirs(TEMP_FOLDER)
-        except:
+        except OSError:
             pass
         self.autosave = AutosaveFile(
             service_name="unittests", file_name="test_file", folder=TEMP_FOLDER
@@ -148,7 +148,4 @@ class TestAutosave(unittest.TestCase):
         assert result == value
 
     def tearDown(self):
-        try:
-            shutil.rmtree(TEMP_FOLDER)
-        except:
-            pass
+        shutil.rmtree(TEMP_FOLDER, ignore_errors=True)

--- a/src/server_common/test_modules/test_channel_access.py
+++ b/src/server_common/test_modules/test_channel_access.py
@@ -4,8 +4,6 @@ import unittest
 from concurrent.futures import wait
 from queue import Empty, Queue
 
-from hamcrest import assert_that, greater_than, has_length, is_, less_than_or_equal_to, none
-
 from server_common.channel_access import (
     NUMBER_OF_CAPUT_THREADS,
     AlarmSeverity,
@@ -58,7 +56,7 @@ class TestChannelAccess(unittest.TestCase):
 
         wait([future])
         time.sleep(3)  # wait for all items to finish
-        assert_that(len(empty_queue(thread_calls)), is_(1), "call is called once")
+        assert len(empty_queue(thread_calls)) == 1, "call is called once"
 
     def test_WHEN_multiple_ca_puts_and_not_wait_THEN_thread_count_is_limited(self):
         initial_thread_count = threading.active_count()
@@ -74,25 +72,21 @@ class TestChannelAccess(unittest.TestCase):
         current_count = threading.active_count()
 
         newly_created_threads = current_count - initial_thread_count
-        assert_that(
-            newly_created_threads,
-            is_(greater_than(NUMBER_OF_CAPUT_THREADS / 2)),
+        assert newly_created_threads > NUMBER_OF_CAPUT_THREADS / 2, (
             "Number of threads running (thread count: initial {} current {})".format(
                 initial_thread_count, current_count
-            ),
+            )
         )
 
-        assert_that(
-            newly_created_threads,
-            is_(less_than_or_equal_to(NUMBER_OF_CAPUT_THREADS)),
+        assert newly_created_threads <= NUMBER_OF_CAPUT_THREADS, (
             "Number of threads running (thread count: initial {} current {})".format(
                 initial_thread_count, current_count
-            ),
+            )
         )
 
         wait(the_future)
         time.sleep(3)  # wait for all items to finish
-        assert_that(len(empty_queue(thread_calls)), is_(2 * NUMBER_OF_CAPUT_THREADS))
+        assert len(empty_queue(thread_calls)) == 2 * NUMBER_OF_CAPUT_THREADS
 
     def test_WHEN_multiple_ca_puts_THEN_a_limited_number_of_threads_are_used(self):
         # This is so the same ca context and channels are used
@@ -110,31 +104,27 @@ class TestChannelAccess(unittest.TestCase):
 
         ids = set(empty_queue(thread_ids))
 
-        assert_that(
-            ids,
-            has_length(NUMBER_OF_CAPUT_THREADS),
-            "Number of ids should be the same as number of threads so that multiple tasks use the same thread",
-        )
+        assert len(ids) == NUMBER_OF_CAPUT_THREADS
 
 
 class TestMaximumSeverity(unittest.TestCase):
     def test_GIVEN_empty_list_WHEN_get_THEN_None_returned(self):
         result = maximum_severity()
 
-        assert_that(result, is_(none()))
+        assert result is None
 
     def test_GIVEN_one_entry_WHEN_get_THEN_that_entry_returned(self):
         no_alarms = (AlarmSeverity.No, AlarmStatus.No)
         result = maximum_severity(no_alarms)
 
-        assert_that(result, is_(no_alarms))
+        assert result == no_alarms
 
     def test_GIVEN_none_and_minor_WHEN_get_THEN_minor_returned(self):
         no_alarms = (AlarmSeverity.No, AlarmStatus.No)
         minor_alarm = (AlarmSeverity.Minor, AlarmStatus.Low)
         result = maximum_severity(minor_alarm, no_alarms)
 
-        assert_that(result, is_(minor_alarm))
+        assert result == minor_alarm
 
     def test_GIVEN_no_and_minor_major_WHEN_get_THEN_major_returned(self):
         no_alarms = (AlarmSeverity.No, AlarmStatus.No)
@@ -142,7 +132,7 @@ class TestMaximumSeverity(unittest.TestCase):
         major_alarm = (AlarmSeverity.Major, LOLO_ALARM_STATUS)
         result = maximum_severity(minor_alarm, major_alarm, no_alarms)
 
-        assert_that(result, is_(major_alarm))
+        assert result == major_alarm
 
     def test_GIVEN_no_minor_major_and_invalid_WHEN_get_THEN_invalid_returned(self):
         no_alarms = (AlarmSeverity.No, AlarmStatus.No)
@@ -151,7 +141,7 @@ class TestMaximumSeverity(unittest.TestCase):
         invalid_alarm = (AlarmSeverity.Invalid, AlarmStatus.Timeout)
         result = maximum_severity(minor_alarm, invalid_alarm, major_alarm, no_alarms)
 
-        assert_that(result, is_(invalid_alarm))
+        assert result == invalid_alarm
 
     def test_GIVEN_two_minor_alarms_WHEN_get_THEN_first_returned(self):
         minor_alarm1 = (AlarmSeverity.Minor, AlarmStatus.Low)
@@ -159,4 +149,4 @@ class TestMaximumSeverity(unittest.TestCase):
 
         result = maximum_severity(minor_alarm1, minor_alarm2)
 
-        assert_that(result, is_(minor_alarm1))
+        assert result == minor_alarm1

--- a/src/server_common/test_modules/test_channel_access.py
+++ b/src/server_common/test_modules/test_channel_access.py
@@ -26,7 +26,7 @@ except AttributeError:
 def set_pv_value(*args, **kwargs):
     """Mock method with set pv value signature, must take some time to work"""
     thread_calls.put((args, kwargs))
-    thread_ids.put(threading.currentThread().ident)
+    thread_ids.put(threading.current_thread().ident)
     time.sleep(0.5)
 
 

--- a/src/server_common/test_modules/test_common_utilities.py
+++ b/src/server_common/test_modules/test_common_utilities.py
@@ -15,7 +15,7 @@ class TestCreatePVName(unittest.TestCase):
         pv = create_pv_name("config name", [], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv, "CONFIG")
+        assert pv == "CONFIG"
 
     def test_WHEN_pv_name_contains_non_alphanumeric_characters_THEN_remove_non_alphanumeric_characters(
         self,
@@ -24,7 +24,7 @@ class TestCreatePVName(unittest.TestCase):
         pv = create_pv_name("c-onf@ig", [], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv, "CONFIG")
+        assert pv == "CONFIG"
 
     def test_WHEN_pv_name_contains_only_numbers_and_underscores_THEN_replace_pv_with_default_pv_name(
         self,
@@ -33,14 +33,14 @@ class TestCreatePVName(unittest.TestCase):
         pv = create_pv_name("1_2_3_4", [], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv, "PEEVEE")
+        assert pv == "PEEVEE"
 
     def test_WHEN_pv_name_is_blank_THEN_replace_pv_with_default_pv_name(self):
         # Act
         pv = create_pv_name("", [], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv, "PEEVEE")
+        assert pv == "PEEVEE"
 
     def test_GIVEN_blank_pv_name_WHEN_another_blank_pv_name_THEN_append_numbers(self):
         # Arrange
@@ -51,16 +51,16 @@ class TestCreatePVName(unittest.TestCase):
         pv_03 = create_pv_name("", [pv_01, pv_02], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv_01, "PEEVEE")
-        self.assertEquals(pv_02, "PEEV01")
-        self.assertEquals(pv_03, "PEEV02")
+        assert pv_01 == "PEEVEE"
+        assert pv_02 == "PEEV01"
+        assert pv_03 == "PEEV02"
 
     def test_WHEN_pv_name_too_long_THEN_truncate_to_six_chars(self):
         # Act
         pv = create_pv_name("Configuration", [], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv, "CONFIG")
+        assert pv == "CONFIG"
 
     def test_GIVEN_an_existing_pv_WHEN_create_another_pv_of_same_name_THEN_append_numbers(self):
         # Arrange
@@ -70,8 +70,8 @@ class TestCreatePVName(unittest.TestCase):
         pv_02 = create_pv_name("Conf", [pv_01], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv_01, "CONF")
-        self.assertEquals(pv_02, "CONF01")
+        assert pv_01 == "CONF"
+        assert pv_02 == "CONF01"
 
     def test_GIVEN_an_existing_truncated_pv_WHEN_another_pv_of_same_name_THEN_truncate_and_rename_differently(
         self,
@@ -84,9 +84,9 @@ class TestCreatePVName(unittest.TestCase):
         pv_03 = create_pv_name("Configuration", [pv_01, pv_02], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv_01, "CONFIG")
-        self.assertEquals(pv_02, "CONF01")
-        self.assertEquals(pv_03, "CONF02")
+        assert pv_01 == "CONFIG"
+        assert pv_02 == "CONF01"
+        assert pv_03 == "CONF02"
 
     def test_GIVEN_a_long_pv_WHEN_create_pv_with_same_name_and_invalid_chars_THEN_remove_invalid_chars_and_truncate_and_number_correctly(
         self,
@@ -98,22 +98,22 @@ class TestCreatePVName(unittest.TestCase):
         pv_02 = create_pv_name("Co*&^nfiguration", [pv_01], "PEEVEE")
 
         # Assert
-        self.assertEquals(pv_01, "CONFIG")
-        self.assertEquals(pv_02, "CONF01")
+        assert pv_01 == "CONFIG"
+        assert pv_02 == "CONF01"
 
     def test_GIVEN_pv_name_contains_a_colon_WHEN_colons_not_allowed_THEN_colons_removed(self):
         # Act
         pv = create_pv_name("BL:AH:BL:", [], "PEEVEE", allow_colon=False)
 
         # Assert
-        self.assertEquals(pv, "BLAHBL")
+        assert pv == "BLAHBL"
 
     def test_GIVEN_pv_name_contains_a_colon_WHEN_colons_allowed_THEN_colons_retained(self):
         # Act
         pv = create_pv_name("BL:AH:BL:", [], "PEEVEE", allow_colon=True)
 
         # Assert
-        self.assertEquals(pv, "BL:AH:BL"[:6])
+        assert pv == "BL:AH:BL"[:6]
 
     def test_WHEN_string_contains_ending_THEN_ending_removed(self):
         # Arrange
@@ -124,7 +124,7 @@ class TestCreatePVName(unittest.TestCase):
         result = remove_from_end(text + ending, ending)
 
         # Assert
-        self.assertEquals(text, result)
+        assert text == result
 
     def test_WHEN_string_does_not_contains_ending_THEN_text_returned(self):
         # Arrange
@@ -135,7 +135,7 @@ class TestCreatePVName(unittest.TestCase):
         result = remove_from_end(text, ending)
 
         # Assert
-        self.assertEquals(text, result)
+        assert text == result
 
     def test_WHEN_string_is_empty_THEN_empty_text_returned(self):
         # Arrange
@@ -146,7 +146,7 @@ class TestCreatePVName(unittest.TestCase):
         result = remove_from_end(text, ending)
 
         # Assert
-        self.assertEquals(text, result)
+        assert text == result
 
     def test_WHEN_string_is_None_THEN_None_returned(self):
         # Arrange
@@ -157,7 +157,7 @@ class TestCreatePVName(unittest.TestCase):
         result = remove_from_end(text, ending)
 
         # Assert
-        self.assertIsNone(result)
+        assert result is None
 
 
 class TestMakeUniqueAndLowercase(unittest.TestCase):

--- a/src/server_common/test_modules/test_file_path_manager.py
+++ b/src/server_common/test_modules/test_file_path_manager.py
@@ -29,7 +29,7 @@ CONFIG_PATH = "./test_configs/"
 SCRIPT_PATH = "./test_scripts/"
 
 
-SCHEMA_PATH = files("server_common.schema").joinpath("")
+SCHEMA_PATH = files("server_common.schema")
 
 
 class TestFilePathManagerSequence(unittest.TestCase):

--- a/src/server_common/test_modules/test_ioc_data_source.py
+++ b/src/server_common/test_modules/test_ioc_data_source.py
@@ -16,8 +16,8 @@
 
 import unittest
 
+import pytest
 from genie_python.mysql_abstraction_layer import AbstractSQLCommands, DatabaseError
-from hamcrest import *
 from mock import Mock
 
 from server_common.ioc_data_source import IocDataSource
@@ -55,7 +55,7 @@ class TestIocDataSource(unittest.TestCase):
 
         result = data_source.get_pv_logging_info()
 
-        assert_that(result, is_(expected_result))
+        assert result == expected_result
 
     def test_GIVEN_no_logging_annotations_request_WHEN_get_values_THEN_empty_dictionary_returned(
         self,
@@ -67,7 +67,7 @@ class TestIocDataSource(unittest.TestCase):
 
         result = data_source.get_pv_logging_info()
 
-        assert_that(result, is_(expected_result))
+        assert result == expected_result
 
     def test_GIVEN_multiple_logging_annotations_over_multiple_iocs_WHEN_get_values_THEN_values_returned_grouped_by_ioc(
         self,
@@ -87,14 +87,15 @@ class TestIocDataSource(unittest.TestCase):
 
         result = data_source.get_pv_logging_info()
 
-        assert_that(result, is_(expected_result))
+        assert result == expected_result
 
     def test_GIVEN_database_error_WHEN_get_values_THEN_error(self):
         mysql_abstraction_layer = SQLAbstractionStubForIOC({})
         mysql_abstraction_layer.query = Mock(side_effect=DatabaseError("DB Error"))
         data_source = IocDataSource(mysql_abstraction_layer)
 
-        assert_that(calling(data_source.get_pv_logging_info), raises(DatabaseError))
+        with pytest.raises(DatabaseError):
+            data_source.get_pv_logging_info()
 
     def test_GIVEN_ioc_with_pvs_WHEN_pvdump_THEN_calls_are_made_to_delete_previous_entries(self):
         mysql_abstraction_layer = SQLAbstractionStubForIOC({})
@@ -102,8 +103,8 @@ class TestIocDataSource(unittest.TestCase):
 
         data_source.insert_ioc_start("name", 12, "path", {}, "prefix")
 
-        assert_that(mysql_abstraction_layer.sql[0], contains_string("DELETE FROM iocrt"))
-        assert_that(mysql_abstraction_layer.sql[1], contains_string("DELETE FROM pvs"))
+        assert "DELETE FROM iocrt" in mysql_abstraction_layer.sql[0]
+        assert "DELETE FROM pvs" in mysql_abstraction_layer.sql[1]
 
     def test_GIVEN_ioc_with_pvs_WHEN_pvdump_has_database_error_THEN_no_exception_raised(self):
         mysql_abstraction_layer = SQLAbstractionStubForIOC({})
@@ -118,7 +119,7 @@ class TestIocDataSource(unittest.TestCase):
 
         data_source.insert_ioc_start("name", 12, "path", {}, "prefix")
 
-        assert_that(mysql_abstraction_layer.sql[2], contains_string("INSERT INTO iocrt"))
+        assert "INSERT INTO iocrt" in mysql_abstraction_layer.sql[2]
 
     def test_GIVEN_ioc_with_pvs_WHEN_pvdump_THEN_calls_are_made_to_add_pvs_with_correct_types_and_names_and_default_type_is_float(
         self,
@@ -140,15 +141,17 @@ class TestIocDataSource(unittest.TestCase):
         data_source.insert_ioc_start(iocname, 12, "path", pvs, prefix)
 
         for sql in mysql_abstraction_layer.sql[3:5]:
-            assert_that(sql, contains_string("INSERT INTO pvs"))
+            assert "INSERT INTO pvs" in sql
 
-        assert_that(
-            mysql_abstraction_layer.sql_param[3:5],
-            contains_inanyorder(
-                (expected_name1, expected_type1, description, iocname),
-                (expected_name2, expected_type2, "", iocname),
-            ),
-        )
+        assert (
+            expected_name1,
+            expected_type1,
+            description,
+            iocname,
+        ) in mysql_abstraction_layer.sql_param[3:5]
+        assert (expected_name2, expected_type2, "", iocname) in mysql_abstraction_layer.sql_param[
+            3:5
+        ]
 
     def test_GIVEN_ioc_with_pvs_with_pv_info_WHEN_pvdump_THEN_calls_are_made_to_add_pv_info_with_correct_pv_names_info_names_and_values(
         self,
@@ -167,9 +170,7 @@ class TestIocDataSource(unittest.TestCase):
         data_source.insert_ioc_start("name", 12, "path", pvs, prefix)
 
         for sql in mysql_abstraction_layer.sql[4:]:
-            assert_that(sql, contains_string("INSERT INTO pvinfo"))
+            assert "INSERT INTO pvinfo" in sql
 
-        assert_that(
-            mysql_abstraction_layer.sql_param[4:],
-            contains_inanyorder((expected_name1, name1, value1), (expected_name1, name2, value2)),
-        )
+        assert (expected_name1, name1, value1) in mysql_abstraction_layer.sql_param[4:]
+        assert (expected_name1, name2, value2) in mysql_abstraction_layer.sql_param[4:]

--- a/src/server_common/test_modules/test_ioc_data_source.py
+++ b/src/server_common/test_modules/test_ioc_data_source.py
@@ -18,7 +18,7 @@ import unittest
 
 import pytest
 from genie_python.mysql_abstraction_layer import AbstractSQLCommands, DatabaseError
-from mock import Mock
+from unittest.mock import Mock
 
 from server_common.ioc_data_source import IocDataSource
 

--- a/src/server_common/test_modules/test_ioc_data_source.py
+++ b/src/server_common/test_modules/test_ioc_data_source.py
@@ -15,10 +15,10 @@
 # http://opensource.org/licenses/eclipse-1.0.php
 
 import unittest
+from unittest.mock import Mock
 
 import pytest
 from genie_python.mysql_abstraction_layer import AbstractSQLCommands, DatabaseError
-from unittest.mock import Mock
 
 from server_common.ioc_data_source import IocDataSource
 

--- a/src/server_common/test_modules/test_log_writer.py
+++ b/src/server_common/test_modules/test_log_writer.py
@@ -4,7 +4,6 @@ import os
 import re
 import unittest
 from datetime import datetime
-
 from unittest.mock import Mock, patch
 
 from server_common.loggers.isis_logger import IsisLogger, IsisPutLog

--- a/src/server_common/test_modules/test_log_writer.py
+++ b/src/server_common/test_modules/test_log_writer.py
@@ -5,7 +5,7 @@ import re
 import unittest
 from datetime import datetime
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from server_common.loggers.isis_logger import IsisLogger, IsisPutLog
 

--- a/src/server_common/test_modules/test_log_writer.py
+++ b/src/server_common/test_modules/test_log_writer.py
@@ -5,7 +5,6 @@ import re
 import unittest
 from datetime import datetime
 
-from hamcrest import *
 from mock import Mock, patch
 
 from server_common.loggers.isis_logger import IsisLogger, IsisPutLog
@@ -30,7 +29,7 @@ class TestISISLog(unittest.TestCase):
         logger.stop_thread_pool()
 
         sent_xml = mock_socket.sendall.call_args[0][0]
-        assert_that(str(sent_xml), contains_string(message))
+        assert message in str(sent_xml)
 
     @patch("socket.socket")
     def test_GIVEN_logger_WHEN_message_sent_THEN_connection_on_logger_port_is_opened_and_close(
@@ -58,7 +57,7 @@ class TestISISLog(unittest.TestCase):
         IsisLogger.executor.shutdown(wait=True)
 
         sent_xml = mock_socket.sendall.call_args[0][0]
-        assert_that(str(sent_xml), contains_string(expected_ioc_name))
+        assert expected_ioc_name in str(sent_xml)
 
     @patch("socket.socket")
     def test_GIVEN_logger_with_ioc_name_WHEN_message_sent_THEN_message_contains_ioc_name(
@@ -74,7 +73,7 @@ class TestISISLog(unittest.TestCase):
         IsisLogger.executor.shutdown(wait=True)
 
         sent_xml = mock_socket.sendall.call_args[0][0]
-        assert_that(str(sent_xml), contains_string(expected_ioc_name))
+        assert expected_ioc_name in str(sent_xml)
 
     @patch("socket.socket")
     def test_GIVEN_logger_with_ioc_name_WHEN_message_sent_with_ioc_name_THEN_message_contains_sent_ioc_name(
@@ -90,7 +89,7 @@ class TestISISLog(unittest.TestCase):
         IsisLogger.executor.shutdown(wait=True)
 
         sent_xml = mock_socket.sendall.call_args[0][0]
-        assert_that(str(sent_xml), contains_string(expected_ioc_name))
+        assert expected_ioc_name in str(sent_xml)
 
     @patch("socket.socket")
     @patch("datetime.datetime")
@@ -116,4 +115,4 @@ class TestISISLog(unittest.TestCase):
 
         sent_xml = mock_socket.sendall.call_args[0][0]
         match = re.search("<!\[CDATA\[(.*)\]\]>", str(sent_xml))
-        assert_that(match.group(1), is_(expected_message))
+        assert match.group(1) == expected_message

--- a/src/server_common/test_modules/test_observable.py
+++ b/src/server_common/test_modules/test_observable.py
@@ -1,3 +1,4 @@
+# type: ignore
 import unittest
 from collections import namedtuple
 

--- a/src/server_common/test_modules/test_observable.py
+++ b/src/server_common/test_modules/test_observable.py
@@ -1,7 +1,7 @@
 import unittest
 from collections import namedtuple
 
-from hamcrest import *
+import pytest
 
 from server_common.observable import observable
 
@@ -46,7 +46,7 @@ class TestObservable(unittest.TestCase):
 
         simple_observable.set_value(expected_value)
 
-        assert_that(self.value, is_(expected_value))
+        assert self.value == expected_value
 
     def test_GIVEN_class_with_observed_type_WHEN_not_add_listener_and_trigger_THEN_nothing_triggered(
         self,
@@ -58,7 +58,7 @@ class TestObservable(unittest.TestCase):
 
         simple_observable.set_value(1)
 
-        assert_that(self.value, is_(expected_value))
+        assert self.value == expected_value
 
     def test_GIVEN_class_with_observed_type_WHEN_call_trigger_of_wrong_type_THEN_error(self):
         @observable(ValueUpdate)
@@ -68,15 +68,14 @@ class TestObservable(unittest.TestCase):
 
         simple_observable = SimpleObservable()
 
-        assert_that(calling(simple_observable.set_value).with_args(1), raises(TypeError))
+        with pytest.raises(TypeError):
+            simple_observable.set_value(1)
 
     def test_GIVEN_class_with_observed_type_WHEN_call_add_listener_of_wrong_type_THEN_error(self):
         simple_observable = SimpleObservable()
 
-        assert_that(
-            calling(simple_observable.add_listener).with_args(NotValueUpdate, self.listener),
-            raises(TypeError),
-        )
+        with pytest.raises(TypeError):
+            simple_observable.add_listener(NotValueUpdate, self.listener)
 
     def test_GIVEN_class_with_observed_type_WHEN_add_2_listeners_and_trigger_THEN_both_triggers_happen(
         self,
@@ -88,8 +87,8 @@ class TestObservable(unittest.TestCase):
 
         simple_observable.set_value(1)
 
-        assert_that(self.value, is_(expected_value))
-        assert_that(self.value2, is_(expected_value))
+        assert self.value == expected_value
+        assert self.value2 == expected_value
 
     def test_GIVEN_class_with_observed_type_WHEN_add_listener_and_trigger_twice_THEN_listeners_triggers_twice(
         self,
@@ -102,7 +101,7 @@ class TestObservable(unittest.TestCase):
         simple_observable.set_value(0)
         simple_observable.set_value(expected_value)
 
-        assert_that(self.value, is_(expected_value))
+        assert self.value == expected_value
 
     def test_GIVEN_two_class_with_observed_type_WHEN_add_listeners_and_triggers_THEN_listeners_triggers_correctly_for_correct_class(
         self,
@@ -118,8 +117,8 @@ class TestObservable(unittest.TestCase):
         simple_observable.set_value(expected_value1)
         simple_observable2.set_value(expected_value2)
 
-        assert_that(self.value, is_(expected_value1))
-        assert_that(self.value2, is_(expected_value2))
+        assert self.value == expected_value1
+        assert self.value2 == expected_value2
 
     def test_GIVEN_class_with_observed_type_WHEN_add_listener_and_remove_listner_and_trigger_THEN_listeners_not_triggers(
         self,
@@ -131,7 +130,7 @@ class TestObservable(unittest.TestCase):
 
         simple_observable.set_value(expected_value)
 
-        assert_that(self.value, is_not(expected_value))
+        assert self.value != expected_value
 
     def test_GIVEN_one_class_with_2_observed_type_WHEN_add_listeners_and_triggers_THEN_listeners_triggers_correctly_for_correct_class(
         self,
@@ -154,8 +153,8 @@ class TestObservable(unittest.TestCase):
         simple_observable.set_value1(expected_value1)
         simple_observable.set_value2(expected_value2)
 
-        assert_that(self.value, is_(expected_value1))
-        assert_that(self.value2, is_(expected_value2))
+        assert self.value == expected_value1
+        assert self.value2 == expected_value2
 
     def test_GIVEN_one_class_observed_type_float_WHEN_add_listeners_and_triggers_THEN_listeners_triggers_correctly_for_correct_class(
         self,
@@ -175,12 +174,12 @@ class TestObservable(unittest.TestCase):
 
         simple_observable.set_value(expected_value1)
 
-        assert_that(self.value, is_(expected_value1))
+        assert self.value == expected_value1
 
     def test_GIVEN_class_with_cached_observed_type_WHEN_get_cache_THEN_default_returned(self):
         simple_observable = SimpleObservable()
 
-        assert_that(simple_observable.listener_last_value(ValueUpdate), is_(None))
+        assert simple_observable.listener_last_value(ValueUpdate) is None
 
     def test_GIVEN_class_with_cached_observed_type_WHEN_set_and_get_cache_THEN_set_value_returned(
         self,
@@ -189,7 +188,7 @@ class TestObservable(unittest.TestCase):
         simple_observable = SimpleObservable()
         simple_observable.set_value(expected_value)
 
-        assert_that(simple_observable.listener_last_value(ValueUpdate).value, is_(expected_value))
+        assert simple_observable.listener_last_value(ValueUpdate).value == expected_value
 
     def test_GIVEN_class_with_observed_type_with_pre_function_WHEN_initialised_THEN_pre_function_is_not_executed(
         self,
@@ -197,7 +196,7 @@ class TestObservable(unittest.TestCase):
         expected_value = 0
         simple_observable = SimpleObservable()
 
-        assert_that(simple_observable.pre_trigger_function_calls, is_(expected_value))
+        assert simple_observable.pre_trigger_function_calls == expected_value
 
     def test_GIVEN_class_with_observed_type_with_pre_function_WHEN_type_is_triggered_THEN_pre_function_is_executed(
         self,
@@ -207,7 +206,7 @@ class TestObservable(unittest.TestCase):
 
         simple_observable.set_value_with_pre_function(1)
 
-        assert_that(simple_observable.pre_trigger_function_calls, is_(expected_value))
+        assert simple_observable.pre_trigger_function_calls == expected_value
 
     def test_GIVEN_class_with_observed_type_with_pre_function_WHEN_other_type_is_triggered_THEN_pre_function_is_not_executed(
         self,
@@ -217,7 +216,7 @@ class TestObservable(unittest.TestCase):
 
         simple_observable.set_value(1)
 
-        assert_that(simple_observable.pre_trigger_function_calls, is_(expected_value))
+        assert simple_observable.pre_trigger_function_calls == expected_value
 
     def test_GIVEN_class_with_observed_type_which_has_triggered_WHEN_add_listener_with_init_on_trigger_THEN_listeners_triggers(
         self,
@@ -228,7 +227,7 @@ class TestObservable(unittest.TestCase):
 
         simple_observable.add_listener(ValueUpdate, self.listener, run_listener=True)
 
-        assert_that(self.value, is_(expected_value))
+        assert self.value == expected_value
 
     def test_GIVEN_class_with_observed_type_which_has_not_triggered_WHEN_add_listener_with_init_on_trigger_THEN_listener_not_triggered(
         self,
@@ -237,5 +236,4 @@ class TestObservable(unittest.TestCase):
         simple_observable = SimpleObservable()
 
         simple_observable.add_listener(ValueUpdate, self.listener, run_listener=True)
-
-        assert_that(self.value, is_(expected_value))
+        assert self.value == expected_value


### PR DESCRIPTION
closes #1 

This PR removes hamcrest, mock and parameterized in favour of pytest and unittest.mock. I think the code quality in general of server_common isn't great, and I didn't want to dive that deep into fixing tests that do file i/o, but at least they shouldn't be depending on windows file locations now... 